### PR TITLE
Error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Grav Anchors Plugin
 
 
-`anchors` is a [Grav](http://github.com/getgrav/grav) plugin that provides automatic header anchors via the [anchorjs](http://bryanbraun.github.io/anchorjs) jQuery plugin.
+`anchors` is a [Grav](http://github.com/getgrav/grav) plugin that provides automatic header anchors via the [anchorjs](http://bryanbraun.github.io/anchorjs) vanilla Javascript plugin.
 
 # Installation
 


### PR DESCRIPTION
There is a statement that anchor.js is a jQuery plugin, it's actually vanilla JS.