### PR TITLE
Fix anchors.add() being called too late

### DIFF
--- a/anchors.php
+++ b/anchors.php
@@ -70,7 +70,7 @@ class AnchorsPlugin extends Plugin
 
             $this->grav['assets']->addJs('plugin://anchors/js/anchor.min.js');
 
-            $anchors_init = "$(document).ready(function() {
+            $anchors_init = "document.addEventListener('DOMContentLoaded', function(event) {
                                 anchors.options = {
                                     $visible
                                     $placement


### PR DESCRIPTION
This PR will fix issue [H4 hyperlink won't jump to it's page position #897](https://github.com/getgrav/grav-learn/issues/897) about anchors not being jumped to by the browser.

See remark at AnchorJS:
> Don't add anchors on later events, like $(document).ready() or window.onload as some browsers will attempt to jump to your ID before AnchorJS can add it to the page. For more details, see [github issue #69](https://github.com/bryanbraun/anchorjs/issues/69#issuecomment-255503575).