### PR TITLE
[fix] Give a11y advice and add title and aria label management

### DIFF
--- a/anchors.php
+++ b/anchors.php
@@ -65,7 +65,9 @@ class AnchorsPlugin extends Plugin
             $placement = "placement: '{$this->config->get('plugins.anchors.placement', 'right')}',";
             $icon = $this->config->get('plugins.anchors.icon') ? "icon: '{$this->config->get('plugins.anchors.icon')}'," : '';
             $class = $this->config->get('plugins.anchors.class') ? "class: '{$this->config->get('plugins.anchors.class')}'," : '';
-            $truncate = "truncate: {$this->config->get('plugins.anchors.truncate', 64)}";
+            $truncate = "truncate: {$this->config->get('plugins.anchors.truncate', 64)},";
+            $ariaLabel = "ariaLabel: '{$this->config->get('plugins.anchors.aria', 'Copy the link to the section: %s')}',";
+            $titleText = "titleText: '{$this->config->get('plugins.anchors.title', 'Copy the link to this section')}',";
             $this->grav['assets']->addJs('plugin://anchors/js/anchor.min.js');
 
             $anchors_init =
@@ -76,6 +78,8 @@ class AnchorsPlugin extends Plugin
                         $icon
                         $class
                         $truncate
+                        $ariaLabel
+                        $titleText
                     };
                     anchors.add('$selectors');
                 });";
@@ -94,7 +98,7 @@ class AnchorsPlugin extends Plugin
                         let anchorjsLinks = document.querySelectorAll(".anchorjs-link");                
                         anchorjsLinks.forEach(el => {
                           el.addEventListener("click", event => {
-                            event.preventDefault();
+                            #event.preventDefault();
                             // add custom "copy to clipboard" code
                             new ClipboardJS(".anchorjs-link");       
                           });

--- a/anchors.php
+++ b/anchors.php
@@ -98,7 +98,6 @@ class AnchorsPlugin extends Plugin
                         let anchorjsLinks = document.querySelectorAll(".anchorjs-link");                
                         anchorjsLinks.forEach(el => {
                           el.addEventListener("click", event => {
-                            #event.preventDefault();
                             // add custom "copy to clipboard" code
                             new ClipboardJS(".anchorjs-link");       
                           });

--- a/anchors.php
+++ b/anchors.php
@@ -66,8 +66,8 @@ class AnchorsPlugin extends Plugin
             $icon = $this->config->get('plugins.anchors.icon') ? "icon: '{$this->config->get('plugins.anchors.icon')}'," : '';
             $class = $this->config->get('plugins.anchors.class') ? "class: '{$this->config->get('plugins.anchors.class')}'," : '';
             $truncate = "truncate: {$this->config->get('plugins.anchors.truncate', 64)},";
-            $ariaLabel = "ariaLabel: '{$this->config->get('plugins.anchors.aria', 'Copy the link to the section: %s')}',";
-            $titleText = "titleText: '{$this->config->get('plugins.anchors.title', 'Copy the link to this section')}',";
+            $ariaLabel = "ariaLabel: '{$this->config->get('plugins.anchors.aria', 'Copy the link and go to this section')}',";
+            $titleText = "titleText: '{$this->config->get('plugins.anchors.title', 'Copy the link and go to this section')}',";
             $this->grav['assets']->addJs('plugin://anchors/js/anchor.min.js');
 
             $anchors_init =

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -75,13 +75,13 @@ form:
       type: text
       label: ARIA label
       help: "Describe the action for blind people using accessibility tools like screen reader"
-      default: "Copy the link to this section"
+      default: "Copy the link and go to this section"
 
     title:
       type: text
       label: Title label
       help: "Describe the action in a tips to help user to understand this icon"
-      default: "Copy the link to this section"
+      default: "Copy the link and go to this section"
 
     icon:
       type: text

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -117,4 +117,4 @@ form:
         0: PLUGIN_ADMIN.DISABLED
       validate:
         type: bool
-      help: Instead of scrolling to the item when clicking, you can enabled this option to copy the link to the clipboard automatically
+      help: In more of scrolling to the item when clicking, you can enabled this option to copy the link to the clipboard automatically

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -54,7 +54,7 @@ form:
       type: select
       label: Placement
       classes: fancy
-      help: "Either `left` or `right`"
+      help: "Either `left` or `right`. Right is recommended for accessibility in order screen reader to read heading before to read"
       default: 'right'
       options:
         'left': 'left'
@@ -65,10 +65,23 @@ form:
       label: Visible
       classes: fancy
       help: "Hover activates on `hover` else will always display"
-      default: 'hover'
+      default: 'touch'
       options:
+        'touch': 'Always display on touch screen and only on hover on others'
         'hover': 'hover'
         'always': 'always'
+
+    aria:
+      type: text
+      label: ARIA label
+      help: "Describe the action for blind people using accessibility tools like screen reader"
+      default: "Copy the link to this section"
+
+    title:
+      type: text
+      label: Title label
+      help: "Describe the action in a tips to help user to understand this icon"
+      default: "Copy the link to this section"
 
     icon:
       type: text
@@ -97,8 +110,8 @@ form:
     copy_to_clipboard:
       type: toggle
       label: Copy to clipboard
-      highlight: 0
-      default: 0
+      highlight: 1
+      default: 1
       options:
         1: PLUGIN_ADMIN.ENABLED
         0: PLUGIN_ADMIN.DISABLED


### PR DESCRIPTION
## The problem
Anchor plugin default settings are not so accessible (a11y):

- No description of the action of the link (some people could not understand the icon)
- No aria label to help screen reader to know which action they trigger
- On touch screen the anchor is not displayed
- The left mode is not good cause with screen reader it reads link before title
- Copy link mode doesn't go to the anchor

## The solution

- Add some help in blueprint form
- Add aria-label and title question in the form
- Add touch mode in more of hover
- Make the copy mode to copy AND go to the link

Important: about aria-label this one should remind the heading text, eg: "Copy and go to the link of the section 'My super heading'". But in this solution, i was not able to do this with the anchor.js library (i think this one should be fixed to allow to support [WCAG 2.1 2.4.4 criteria](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html)...

## States of the PR
Tested on a recent grav.
But i will try to make a PR on anchor.js. It could take time, so i suggest to merge this PR. 
